### PR TITLE
Fix illegal reentracy

### DIFF
--- a/contracts/Multiownable.sol
+++ b/contracts/Multiownable.sol
@@ -8,7 +8,7 @@ contract Multiownable {
     uint256 public howManyOwnersDecide;
     address[] public owners;
     bytes32[] public allOperations;
-    bool insideOnlyManyOwners = false;
+    address insideOnlyManyOwners;
     
     // Reverse lookup tables for owners and allOperations
     mapping(address => uint) ownersIndices; // Starts from 1
@@ -50,7 +50,7 @@ contract Multiownable {
     * @dev Allows to perform method only after all owners call it with the same arguments
     */
     modifier onlyManyOwners {
-        if (insideOnlyManyOwners) {
+        if (insideOnlyManyOwners == msg.sender) {
             _;
             return;
         }
@@ -70,9 +70,9 @@ contract Multiownable {
         // If all owners confirm same operation
         if (votesCountByOperation[operation] == howManyOwnersDecide) {
             deleteOperation(operation);
-            insideOnlyManyOwners = true;
+            insideOnlyManyOwners = msg.sender;
             _;
-            insideOnlyManyOwners = false;
+            insideOnlyManyOwners = address(0);
         }
     }
 

--- a/test/MultiAttack.js
+++ b/test/MultiAttack.js
@@ -1,0 +1,37 @@
+// @flow
+'use strict'
+
+const BigNumber = web3.BigNumber;
+const expect = require('chai').expect;
+const should = require('chai')
+    .use(require('chai-as-promised'))
+    .use(require('chai-bignumber')(web3.BigNumber))
+    .should();
+
+import ether from './helpers/ether';
+import {advanceBlock} from './helpers/advanceToBlock';
+import {increaseTimeTo, duration} from './helpers/increaseTime';
+import latestTime from './helpers/latestTime';
+import EVMThrow from './helpers/EVMThrow';
+
+const MultiAttackable = artifacts.require('./impl/MultiAttackable.sol');
+const MultiAttacker = artifacts.require('./impl/MultiAttacker.sol');
+
+contract('MultiAttack', function ([_, wallet1, wallet2, wallet3, wallet4, wallet5]) {
+
+    it('should handle reentracy attack', async function() {
+        const victim = await MultiAttackable.new();
+        const hacker = await MultiAttacker.new();
+
+        // Prepare victim wallet
+        await victim.transferOwnership([wallet1, wallet2]);
+        await web3.eth.sendTransaction({from: _, to: victim.address, value: ether(3)});
+
+        // Try reentrace attack
+        await victim.transferTo(hacker.address, ether(1), {from: wallet1});
+        await victim.transferTo(hacker.address, ether(1), {from: wallet2});
+
+        (await web3.eth.getBalance(victim.address)).should.be.bignumber.equal(ether(0));
+    })
+
+})

--- a/test/MultiAttack.js
+++ b/test/MultiAttack.js
@@ -29,9 +29,9 @@ contract('MultiAttack', function ([_, wallet1, wallet2, wallet3, wallet4, wallet
 
         // Try reentrace attack
         await victim.transferTo(hacker.address, ether(1), {from: wallet1});
-        await victim.transferTo(hacker.address, ether(1), {from: wallet2});
+        await victim.transferTo(hacker.address, ether(1), {from: wallet2}).should.be.rejectedWith(EVMThrow);
 
-        (await web3.eth.getBalance(victim.address)).should.be.bignumber.equal(ether(0));
+        (await web3.eth.getBalance(victim.address)).should.be.bignumber.equal(ether(3));
     })
 
 })

--- a/test/impl/MultiAttackable.sol
+++ b/test/impl/MultiAttackable.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.4.11;
+
+import "../../contracts/Multiownable.sol";
+
+
+contract MultiAttackable is Multiownable {
+
+    function() public payable {
+    }
+
+    function transferTo(address to, uint256 amount) public onlyManyOwners {
+        require(to.call.value(amount)());
+        //to.transfer(amount);
+    }
+
+}

--- a/test/impl/MultiAttacker.sol
+++ b/test/impl/MultiAttacker.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.4.11;
+
+import "./MultiAttackable.sol";
+
+
+contract MultiAttacker {
+
+    bool avoidRecursionDuringAttack = false;
+
+    function () public payable {
+        if (!avoidRecursionDuringAttack) {
+            avoidRecursionDuringAttack = true;
+            MultiAttackable(msg.sender).transferTo(this, 2 ether);
+            avoidRecursionDuringAttack = false;
+        }
+    }
+
+}


### PR DESCRIPTION
Fix any smart contract ability to re-enter onlyManyOwners method. Only msg.sender is allowed to re-enter.